### PR TITLE
Create requirements.txt so we can run 

### DIFF
--- a/RaidSignupCreator.py
+++ b/RaidSignupCreator.py
@@ -1,33 +1,21 @@
 #!/usr/bin/python3
 
-#Default packages installed with python
+'''
+Keeping this chunk around because I found it useful to remind
+myself what the package names are called in pip
+organized as localName: pip_intaller_name
+"requests":"requests",
+"dotenv":"python-dotenv",
+"dateutil":"python-dateutil"
+'''
+
 import os
 from pathlib import Path
-from datetime import datetime, time, date
-
-from importlib.util import find_spec
-
-#Check for required additional packages
-# Unfortunately, sometimes the pip installer is named differently than the local package
-# So we need a dict to do this - use local_name, pip_intaller_name
-required_packages: dict[str, str] = {
-    "requests":"requests",
-    "dotenv":"python-dotenv",
-    "dateutil":"python-dateutil"
-}
-
-for local_name, pip_name in required_packages.items():
-    if find_spec(local_name) is None:
-        import sys, subprocess
-        subprocess.check_call([sys.executable, '-m', 'pip', 'install', pip_name, '--user'])
-        del sys, subprocess
-
-del find_spec
-
-#Then import them
+from datetime import datetime, date
 import requests
 from dotenv import load_dotenv
 from dateutil.relativedelta import relativedelta
+
 
 def get_raid_datetime(weekday: int, hour: int, minute: int) -> datetime:
     # Get the next instance of the given day

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+certifi==2024.8.30
+charset-normalizer==3.4.0
+idna==3.10
+pip==24.3.1
+python-dateutil==2.9.0.post0
+python-dotenv==1.0.1
+requests==2.32.3
+six==1.16.0
+urllib3==2.2.3


### PR DESCRIPTION
Removed the janky(but cool) import logic we had to check for packages, added requirements.txt so we can run the pip install command before running the script to ensure we have the required packages.